### PR TITLE
Add measurement range and excel export helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# TPower Utilities
+
+This repository contains small utilities to interact with energy measurement services. It currently bundles two
+client libraries:
+
+- `gpm` – a wrapper around GreenPowerMonitor APIs.
+- `prmte` – tools for the "Plataforma de Recolección de Medidas en Tiempo Real" (PRMTE) provided by the
+  Coordinador Eléctrico Nacional in Chile.
+
+## PRMTE library
+
+The PRMTE library now supports the `medidas-v2` API.  A typical workflow is:
+
+```python
+from prmte.core import PRMTEClient
+from prmte.api import get_measurements
+
+client = PRMTEClient(api_key="<YOUR API KEY>")
+# Fetch one month of data at hourly resolution
+df = get_measurements(client, "PM123", period="202401", granularity="1H")
+print(df.head())
+```
+
+### New features
+
+- Support for the new `/measurement` endpoint.
+- Convenience helper :func:`get_measurements` for retrieving and
+  resampling data in one call.
+- `transform_records` now accepts a `last_reading` argument which allows
+  trimming to the last available timestamp.
+
+### Additional helpers
+
+- :func:`get_measurements_range` fetches data between two periods, defaulting to
+  the current month when the end period is omitted.
+- :func:`measurements_to_excel` exports measurements for several assets to an
+  Excel workbook with the mapping table and the consolidated data in either
+  ``long`` or ``wide`` format.
+
+Additional helper methods can be added easily.  See `prmte/core.py` for
+reference.
+

--- a/prmte/api.py
+++ b/prmte/api.py
@@ -55,24 +55,83 @@ def get_puntomedidas(client: PRMTEClient, idCoordinado: str):
     return client.make_api_call('puntomedidas', params={'idCoordinado': idCoordinado})
 
 def get_measurements(client: PRMTEClient, idPuntoMedida: str, period: str, end_period=None, granularity='1H', df_format='consolidated'):
-    """ 
-    Get all measurements for a single measurement point, given a period and optionally an end period.
+    """Fetch measurements for a single point between two periods.
 
-    Args:
-        client: PRMTEClass object.
-        idPuntoMedida (str): the measure point unique identifier.
-        periodo (str): measurement period (monthly granularity) in YYYYMM format.
-        end_period (str): end measurement period in YYYYMM format (optional).
-        granularity (str): resampling rule as of Pandas documentation (see 
-            https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases)
-        df_format (str): either 'consolidated' or 'columns'. See 'transform_records' function in 
-            data package for more information on this parameter.
+    Parameters
+    ----------
+    client : :class:`PRMTEClient`
+        Authenticated client instance.
+    idPuntoMedida : str
+        Identifier for the measure point.
+    period : str
+        Start period in ``YYYYMM`` format.
+    end_period : str, optional
+        End period in ``YYYYMM`` format. When omitted, only ``period`` is
+        retrieved.
+    granularity : str, optional
+        Resampling rule understood by ``pandas.DataFrame.resample``.
+    df_format : str, optional
+        Output format for :func:`transform_records`.
 
-    Returns:
-        A Pandas DataFrame containing all measurements for a single measurement point. If end_period is not None, 
-        the DataFrame contains all periods between 'period' and 'end_period'.
+    Returns
+    -------
+    pandas.DataFrame
+        Measurements indexed by date.
     """
-    pass
+
+    # Build list of periods to query
+    periods = []
+    start = datetime.strptime(period, "%Y%m")
+    end = datetime.strptime(end_period, "%Y%m") if end_period else start
+
+    current = start
+    while current <= end:
+        periods.append(current.strftime("%Y%m"))
+        current += relativedelta(months=1)
+
+    all_frames = []
+    last_reading = None
+
+    for per in periods:
+        records, last_reading = client.get_measurements(idPuntoMedida, per)
+        if not records:
+            continue
+        df = transform_records(records, last_reading, format=df_format)
+        if granularity:
+            df = df.resample(granularity).sum()
+        all_frames.append(df)
+
+    if not all_frames:
+        return pd.DataFrame()
+
+    return pd.concat(all_frames).sort_index()
+
+
+def get_measurements_range(
+    client: PRMTEClient,
+    idPuntoMedida: str,
+    start_period: str,
+    end_period: str | None = None,
+    granularity: str = '1H',
+    df_format: str = 'consolidated',
+):
+    """Fetch measurements from ``start_period`` up to ``end_period``.
+
+    When ``end_period`` is omitted the current month is used.
+    Parameters are otherwise the same as :func:`get_measurements`.
+    """
+
+    if end_period is None:
+        end_period = datetime.utcnow().strftime('%Y%m')
+
+    return get_measurements(
+        client,
+        idPuntoMedida=idPuntoMedida,
+        period=start_period,
+        end_period=end_period,
+        granularity=granularity,
+        df_format=df_format,
+    )
     
 
 def get_historic_measurements(client: PRMTEClient, idPuntoMedida: str, broken_periods=[], granularity='1H', df_format='consolidated'):
@@ -110,5 +169,93 @@ def get_historic_measurements(client: PRMTEClient, idPuntoMedida: str, broken_pe
         total = pd.concat([total, df], axis=0)
 
     return total
+
+
+def get_daily_energy(client: PRMTEClient, idPuntoMedida: str, period: str, end_period=None):
+    """Convenience wrapper returning a daily energy profile.
+
+    Parameters are the same as :func:`get_measurements`.  The resulting
+    DataFrame is resampled to daily totals.
+    """
+
+    df = get_measurements(
+        client,
+        idPuntoMedida=idPuntoMedida,
+        period=period,
+        end_period=end_period,
+        granularity='D',
+    )
+    return df
+
+
+def save_measurements_csv(client: PRMTEClient, idPuntoMedida: str, period: str, filename: str, **kwargs):
+    """Download measurements and save them to ``filename`` in CSV format."""
+
+    df = get_measurements(client, idPuntoMedida, period, **kwargs)
+    df.to_csv(filename)
+    return filename
+
+
+def measurements_to_excel(
+    client: PRMTEClient,
+    assets: dict,
+    period: str,
+    end_period: str | None = None,
+    filename: str = 'measurements.xlsx',
+    granularity: str = '1H',
+    df_format: str = 'long',
+):
+    """Download measurements for multiple assets and export them to Excel.
+
+    Parameters
+    ----------
+    client : :class:`PRMTEClient`
+        Authenticated client instance.
+    assets : dict
+        Mapping ``asset_name -> idPuntoMedida``.
+    period : str
+        Start period in ``YYYYMM`` format.
+    end_period : str, optional
+        End period in ``YYYYMM`` format.  Defaults to the current month when
+        omitted.
+    filename : str, optional
+        Destination file name for the Excel workbook.
+    granularity : str, optional
+        Resampling rule for the measurements.
+    df_format : {"long", "wide"}, optional
+        Output table format.  ``long`` produces one row per asset and date,
+        ``wide`` pivots assets into columns.
+    """
+
+    internal_format = 'consolidated' if df_format.lower() == 'long' else 'columns'
+
+    mapping_df = pd.DataFrame(list(assets.items()), columns=['asset_name', 'idPuntoMedida'])
+    frames = []
+
+    for asset_name, mp_id in assets.items():
+        df = get_measurements_range(
+            client,
+            mp_id,
+            start_period=period,
+            end_period=end_period,
+            granularity=granularity,
+            df_format=internal_format,
+        ).reset_index()
+        if df.empty:
+            continue
+        df['asset_name'] = asset_name
+        frames.append(df)
+
+    measurements = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+
+    if df_format.lower() == 'wide' and not measurements.empty:
+        measurements = measurements.pivot_table(index='date', columns='asset_name', values='value')
+
+    with pd.ExcelWriter(filename) as writer:
+        mapping_df.to_excel(writer, sheet_name='assets', index=False)
+        measurements.to_excel(writer, sheet_name='measurements')
+
+    return filename
+
 
 


### PR DESCRIPTION
## Summary
- expose new `get_measurements_range` wrapper to fetch from a start period up to another
- add `measurements_to_excel` for exporting multiple assets into an Excel workbook
- document both helpers in the README

## Testing
- `python -m compileall -q prmte gpm`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68473132a3a8832bac0ccff3b5763d91